### PR TITLE
fix: SC-199871 Prevent redirect to app error page for external domain errors

### DIFF
--- a/Sources/WebView.swift
+++ b/Sources/WebView.swift
@@ -151,6 +151,17 @@ extension CustomWebView: WKNavigationDelegate {
     
     final func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         showActivityIndicator(show: false)
+        
+        if let initialHost = url?.host,
+           let failingHost = webView.url?.host,
+           initialHost == failingHost {
+            showCustomErrorPage(in: webView)
+        } else if webView.url == nil {
+            showCustomErrorPage(in: webView)
+        }
+    }
+    
+    private func showCustomErrorPage(in webView: WKWebView) {
         let htmlFileName = "error_page.html"
         let frameworkBundle = Bundle(for: type(of: self))
         


### PR DESCRIPTION
Using the same login for showing custom error as on Android SDK.